### PR TITLE
Add retention days option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ See [docker-image-artifact-download](https://github.com/ishworkh/docker-image-ar
 
 **Required** Image name that is to be uploaded.
 
+### `retention_days`
+
+**Optional** Number of retention days passed to underlying [`@actions/artifact uploadArtifact method`](https://github.com/actions/toolkit/tree/main/packages/artifact#available-options) 
+
 ## Outputs
 
 ### `artifact_name`

--- a/index.js
+++ b/index.js
@@ -3,12 +3,13 @@ const { upload } = require('docker-image-artifact');
 const githubActionIO = require('./actions_io');
 
 const INPUT_IMAGE = 'image';
-
+const RETENTION_DAYS= 'retention_days'
 const OUTPUT_ARTIFACT_NAME = 'artifact_name';
 
 async function runAction(getInput, writeOutput) {
     const imageName = getInput(INPUT_IMAGE, true);
-    const artifactName = await upload(imageName);
+    const retentionDays = getInput(RETENTION_DAYS, false);
+    const artifactName = await upload(imageName, retentionDays);
     writeOutput(OUTPUT_ARTIFACT_NAME, artifactName);
 }
 


### PR DESCRIPTION
Requested here - https://github.com/ishworkh/docker-image-artifact-upload/issues/5

The docker-image-artifact upload method already accepts a retention days argument so just utilising it here 